### PR TITLE
Give homes namespace argument

### DIFF
--- a/snowfall-lib/home/default.nix
+++ b/snowfall-lib/home/default.nix
@@ -275,6 +275,7 @@ in {
         config = {
           home-manager.extraSpecialArgs = {
             inherit system target format virtual systems host;
+            inherit (snowfall-config) namespace;
 
             lib = home-lib;
 


### PR DESCRIPTION
Add `namespace` to `home-manager.extraSpecialArgs` so `homes/<arch>/<name>/default.nix` gets `namespace` as an argument